### PR TITLE
Use NDMF pipeline for everything, also enhanced PhysBone configuration

### DIFF
--- a/Assets/VRCBreeze/Editor.meta
+++ b/Assets/VRCBreeze/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1256570b6d7d28f4793ff3c1606b6548
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCBreeze/Editor/VRCBreezeContext.cs
+++ b/Assets/VRCBreeze/Editor/VRCBreezeContext.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor.Animations;
+using VRC.SDK3.Avatars.Components;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.animator;
+
+using UnityRandom = UnityEngine.Random;
+using static UnityEngine.Object;
+
+namespace VRCBreeze
+{
+    [DependsOnContext(typeof(AnimatorServicesContext))]
+    public sealed class VRCBreezeContext : IExtensionContext
+    {
+        BuildContext context;
+        AnimatorServicesContext asc;
+        readonly Dictionary<(VRCBreezeCreator, Direction), VirtualClip> generatedClips = new();
+        VirtualAnimatorController fx;
+        bool writeDefaults;
+
+        public void OnActivate(BuildContext context)
+        {
+            this.context = context;
+            asc = context.Extension<AnimatorServicesContext>();
+            fx = asc.ControllerContext.Controllers[VRCAvatarDescriptor.AnimLayerType.FX];
+            writeDefaults = CalculateWriteDefaults();
+        }
+
+        public void OnDeactivate(BuildContext context)
+        {
+            if (context != this.context) return;
+            fx = null;
+            generatedClips.Clear();
+            asc = null;
+            this.context = null;
+        }
+
+        public void Install(VRCBreezeCreator creator)
+        {
+            if (creator == null) return;
+
+            if (creator.boneObjects.Length == 0) return;
+
+            // Setup Physbones
+            SetupPhysbones(creator);
+
+            // Create animations
+            CreateBreezeAnimation(creator, Direction.Forward);
+            CreateBreezeAnimation(creator, Direction.Backward);
+            CreateBreezeAnimation(creator, Direction.Left);
+            CreateBreezeAnimation(creator, Direction.Right);
+
+            // Assign animations to controller
+            AssignAnimationsToController(creator);
+
+            // Set constraints
+            SetConstraints(creator);
+
+            // Remove creator component
+            DestroyImmediate(creator);
+        }
+
+        private void SetupPhysbones(VRCBreezeCreator creator)
+        {
+            int successfulObjCount = 0;
+            var tempPhysBones = new List<VRCPhysBone>();
+            foreach (var boneObject in creator.boneObjects)
+            {
+                if (boneObject.breezeBone == null) continue;
+                boneObject.breezeBone.GetComponentsInChildren(true, tempPhysBones);
+                foreach (var bone in tempPhysBones)
+                {
+                    if (bone == null) continue;
+                    bone.isAnimated = true;
+                }
+                successfulObjCount++;
+            }
+        }
+
+        private void CreateBreezeAnimation(VRCBreezeCreator creator, Direction direction)
+        {
+            var clip = VirtualClip.Create("N/A");
+
+            foreach (var boneObject in creator.boneObjects)
+            {
+                if (boneObject.breezeBone == null || boneObject.breezeBoneWeight == 0f) continue;
+
+                string path = asc.ObjectPathRemapper.GetVirtualPathForObject(boneObject.breezeBone.transform);
+
+                Vector3 axis = Vector3.up;
+                float angle = creator.windStrength * boneObject.breezeBoneWeight;
+
+                switch (direction)
+                {
+                    case Direction.Forward:
+                        axis = boneObject.invertZ ? Vector3.forward : Vector3.back;
+                        angle = Mathf.Abs(angle);
+                        break;
+                    case Direction.Backward:
+                        axis = boneObject.invertZ ? Vector3.back : Vector3.forward;
+                        angle = Mathf.Abs(angle);
+                        break;
+                    case Direction.Left:
+                        axis = boneObject.invertX ? Vector3.right : Vector3.left;
+                        angle = Mathf.Abs(angle);
+                        break;
+                    case Direction.Right:
+                        axis = boneObject.invertX ? Vector3.left : Vector3.right;
+                        angle = Mathf.Abs(angle);
+                        break;
+                }
+
+                var boneTransform = boneObject.breezeBone.transform;
+                Quaternion worldStartRot = boneTransform.rotation;
+                Vector3 rotationAxis = Vector3.Cross(Vector3.up, axis).normalized;
+                if (rotationAxis == Vector3.zero)
+                    rotationAxis = Vector3.forward;
+
+                Quaternion worldMiddleRot = Quaternion.AngleAxis(angle, rotationAxis) * worldStartRot;
+
+                Quaternion localStartRot = worldStartRot;
+                Quaternion localMiddleRot = worldMiddleRot;
+                var parent = boneTransform.parent;
+                if (parent != null)
+                {
+                    localStartRot = Quaternion.Inverse(parent.rotation) * localStartRot;
+                    localMiddleRot = Quaternion.Inverse(parent.rotation) * localMiddleRot;
+                }
+
+                float keyframeTime = creator.moveBonesAtRandomTime ? UnityRandom.Range(0.35f, 0.65f) : 0.5f;
+
+                var curveX = new AnimationCurve(new Keyframe(0f, localStartRot.x), new Keyframe(keyframeTime, localMiddleRot.x), new Keyframe(1f, localStartRot.x));
+                var curveY = new AnimationCurve(new Keyframe(0f, localStartRot.y), new Keyframe(keyframeTime, localMiddleRot.y), new Keyframe(1f, localStartRot.y));
+                var curveZ = new AnimationCurve(new Keyframe(0f, localStartRot.z), new Keyframe(keyframeTime, localMiddleRot.z), new Keyframe(1f, localStartRot.z));
+                var curveW = new AnimationCurve(new Keyframe(0f, localStartRot.w), new Keyframe(keyframeTime, localMiddleRot.w), new Keyframe(1f, localStartRot.w));
+
+                clip.SetFloatCurve(path, typeof(Transform), "localRotation.x", curveX);
+                clip.SetFloatCurve(path, typeof(Transform), "localRotation.y", curveY);
+                clip.SetFloatCurve(path, typeof(Transform), "localRotation.z", curveZ);
+                clip.SetFloatCurve(path, typeof(Transform), "localRotation.w", curveW);
+            }
+
+            clip.WrapMode = WrapMode.Loop;
+
+            switch (direction)
+            {
+                case Direction.Left:
+                    clip.Name = "VRCBreeze_+X";
+                    generatedClips[(creator, Direction.Left)] = clip;
+                    break;
+                case Direction.Right:
+                    clip.Name = "VRCBreeze_-X";
+                    generatedClips[(creator, Direction.Right)] = clip;
+                    break;
+                case Direction.Forward:
+                    clip.Name = "VRCBreeze_+Z";
+                    generatedClips[(creator, Direction.Forward)] = clip;
+                    break;
+                case Direction.Backward:
+                    clip.Name = "VRCBreeze_-Z";
+                    generatedClips[(creator, Direction.Backward)] = clip;
+                    break;
+            }
+        }
+
+        private void AssignAnimationsToController(VRCBreezeCreator creator)
+        {
+            if (!asc.ControllerContext.Controllers.TryGetValue(creator, out var sourceAnimatorController))
+            {
+                return;
+            }
+
+            VirtualLayer fxLayer = null;
+            foreach (var layer in sourceAnimatorController.Layers)
+            {
+                if (string.Equals(layer.Name, "breeze", StringComparison.OrdinalIgnoreCase))
+                {
+                    fxLayer = layer;
+                    break;
+                }
+            }
+
+            if (fxLayer == null)
+            {
+                return;
+            }
+
+            VirtualState hairState = null;
+            foreach (var state in fxLayer.StateMachine.AllStates())
+            {
+                if (string.Equals(state.Name, "breeze blend tree", StringComparison.OrdinalIgnoreCase))
+                {
+                    hairState = state;
+                    break;
+                }
+            }
+            if (hairState == null)
+            {
+                return;
+            }
+
+            var blendTree = hairState.Motion as VirtualBlendTree;
+            if (blendTree == null)
+            {
+                return;
+            }
+
+            // Breeze Tree
+
+            VirtualBlendTree breezeTree = null;
+            foreach (var child in blendTree.Children)
+            {
+                if (child.Motion is VirtualBlendTree bt && string.Equals(bt.Name, "breeze tree", StringComparison.OrdinalIgnoreCase))
+                {
+                    breezeTree = bt;
+                    break;
+                }
+            }
+            if (breezeTree == null)
+            {
+                return;
+            }
+
+            // Breeze World
+
+            VirtualBlendTree breezeWorld = null;
+            foreach (var child in breezeTree.Children)
+            {
+                if (child.Motion is VirtualBlendTree bt && string.Equals(bt.Name, "world", StringComparison.OrdinalIgnoreCase))
+                {
+                    breezeWorld = bt;
+                    break;
+                }
+            }
+            if (breezeWorld == null)
+            {
+                return;
+            }
+
+            var worldChildren = breezeWorld.Children;
+            if (worldChildren.Count < 4)
+            {
+                return;
+            }
+
+            worldChildren[(int)Direction.Left].Motion = generatedClips[(creator, Direction.Left)];
+            worldChildren[(int)Direction.Right].Motion = generatedClips[(creator, Direction.Right)];
+            worldChildren[(int)Direction.Forward].Motion = generatedClips[(creator, Direction.Forward)];
+            worldChildren[(int)Direction.Backward].Motion = generatedClips[(creator, Direction.Backward)];
+
+            breezeWorld.Children = worldChildren;
+
+            // Breeze Local
+
+            VirtualBlendTree breezeLocal = null;
+            foreach (var child in breezeTree.Children)
+            {
+                if (child.Motion is VirtualBlendTree bt && string.Equals(bt.Name, "local", StringComparison.OrdinalIgnoreCase))
+                {
+                    breezeLocal = bt;
+                    break;
+                }
+            }
+            if (breezeLocal == null)
+            {
+                return;
+            }
+
+            var localChildren = breezeLocal.Children;
+            if (localChildren.Count < 5)
+            {
+                return;
+            }
+
+            localChildren[0].Motion = generatedClips[(creator, Direction.Forward)];
+            localChildren[1].Motion = generatedClips[(creator, Direction.Left)];
+            localChildren[2].Motion = generatedClips[(creator, Direction.Backward)];
+            localChildren[3].Motion = generatedClips[(creator, Direction.Right)];
+            localChildren[4].Motion = generatedClips[(creator, Direction.Forward)];
+
+            breezeLocal.Children = localChildren;
+
+            // Install the modified controller to main FX layer
+            fx.Parameters = fx.Parameters.SetItems(sourceAnimatorController.Parameters);
+            foreach (var layer in sourceAnimatorController.Layers)
+            {
+                foreach (var state in layer.StateMachine.AllStates())
+                    state.WriteDefaultValues = writeDefaults;
+                fx.AddLayer(LayerPriority.Default, layer);
+            }
+        }
+
+        private void SetConstraints(VRCBreezeCreator creator)
+        {
+            if (creator.rotationConstraint == null)
+            {
+                return;
+            }
+            if (creator.windAnchor == null)
+            {
+                return;
+            }
+            creator.rotationConstraint.Sources.Clear();
+
+            creator.rotationConstraint.Sources.Add(new()
+            {
+                SourceTransform = creator.windAnchor.transform,
+                Weight = 1f
+            });
+
+            creator.rotationConstraint.ActivateConstraint();
+        }
+
+        public bool CalculateWriteDefaults()
+        {
+            int wdOffCount = 0, wdOnCount = 0;
+            foreach (var layer in fx.Layers)
+            {
+                if (layer.BlendingMode == AnimatorLayerBlendingMode.Additive)
+                    continue;
+                var stateMachine = layer.StateMachine;
+                if (stateMachine.StateMachines.Count == 0 &&
+                    stateMachine.States.Count == 1 &&
+                    stateMachine.AnyStateTransitions.Count == 0)
+                {
+                    var defaultState = stateMachine.DefaultState;
+                    if (defaultState != null &&
+                        defaultState.Transitions.Count == 0 &&
+                        defaultState.Motion is VirtualBlendTree)
+                        continue;
+                }
+                foreach (var state in stateMachine.AllStates())
+                    if (state.WriteDefaultValues)
+                        wdOnCount++;
+                    else
+                        wdOffCount++;
+            }
+            return wdOnCount > wdOffCount;
+        }
+    }
+}

--- a/Assets/VRCBreeze/Editor/VRCBreezeContext.cs
+++ b/Assets/VRCBreeze/Editor/VRCBreezeContext.cs
@@ -65,18 +65,29 @@ namespace VRCBreeze
 
         private void SetupPhysbones(VRCBreezeCreator creator)
         {
-            int successfulObjCount = 0;
-            var tempPhysBones = new List<VRCPhysBone>();
+            var allPhysBones = context.AvatarRootObject.GetComponentsInChildren<VRCPhysBone>(true);
+            if (allPhysBones.Length == 0) return;
             foreach (var boneObject in creator.boneObjects)
             {
                 if (boneObject.breezeBone == null) continue;
-                boneObject.breezeBone.GetComponentsInChildren(true, tempPhysBones);
-                foreach (var bone in tempPhysBones)
+                var boneTransform = boneObject.breezeBone.transform;
+                foreach (var pb in allPhysBones)
                 {
-                    if (bone == null) continue;
-                    bone.isAnimated = true;
+                    var transform = pb.GetRootTransform();
+                    if (transform == boneTransform || boneTransform.IsChildOf(transform))
+                    {
+                        bool isIgnored = false;
+                        foreach (var ignoreTransform in pb.ignoreTransforms)
+                        {
+                            if (ignoreTransform == boneTransform || boneTransform.IsChildOf(ignoreTransform))
+                            {
+                                isIgnored = true;
+                                break;
+                            }
+                        }
+                        if (!isIgnored) pb.isAnimated = true;
+                    }
                 }
-                successfulObjCount++;
             }
         }
 

--- a/Assets/VRCBreeze/Editor/VRCBreezeContext.cs.meta
+++ b/Assets/VRCBreeze/Editor/VRCBreezeContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e909d0a3ff3e0d34e9c87071f70d0e65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCBreeze/Editor/VRCBreezeEditor.cs
+++ b/Assets/VRCBreeze/Editor/VRCBreezeEditor.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+using UnityEditor;
+
+namespace VRCBreeze
+{
+    #region Editor
+    [CustomEditor(typeof(VRCBreezeCreator))]
+    public sealed class VRCBreezeEditor : Editor
+    {
+        private Texture2D header_mainTexture;
+        private Rect headerSection;
+        private float headerSize = 100f;
+
+        private static GUIStyle DefaultButtonStyle => new GUIStyle(GUI.skin.button)
+        {
+            fontStyle = FontStyle.Normal,
+            alignment = TextAnchor.MiddleCenter,
+            richText = true,
+            wordWrap = true,
+        };
+        private static GUIStyle DefaultButtonStyleUnwrap => new GUIStyle(GUI.skin.button)
+        {
+            fontStyle = FontStyle.Normal,
+            alignment = TextAnchor.MiddleCenter,
+            richText = true,
+            wordWrap = false,
+        };
+
+        private void OnEnable()
+        {
+            header_mainTexture = Resources.Load<Texture2D>("VRCB_Header");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            VRCBreezeCreator creator = (VRCBreezeCreator)target;
+            if (creator == null) return;
+
+            if (header_mainTexture != null)
+            {
+                headerSection.height = headerSize;
+                headerSection.width = headerSize * 3.94f;
+                headerSection.x = 0f;/*(Screen.width / 2) - headerSection.width / 2;*/
+                headerSection.y = 0f;
+
+                GUI.DrawTexture(headerSection, header_mainTexture);
+
+                EditorGUILayout.Space(headerSection.height);
+            }
+
+            EditorGUILayout.BeginHorizontal();
+            //GUILayout.FlexibleSpace();
+            EditorGUILayout.LabelField("Created by:", GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/);
+            if (GUILayout.Button("Kadeko", DefaultButtonStyleUnwrap, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/))
+                Application.OpenURL("https://x.com/kadeko_vrc");
+            if (GUILayout.Button("InviaWaffles", DefaultButtonStyleUnwrap, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/))
+                Application.OpenURL("https://x.com/InviaWaffles");
+            EditorGUILayout.EndHorizontal();
+
+            if (GUILayout.Button("Help & Documentation", DefaultButtonStyleUnwrap, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/))
+                Application.OpenURL("https://github.com/Kadeko/VRCBreeze/");
+
+            EditorGUILayout.Space(15f);
+
+            DrawDefaultInspector();
+        }
+    }
+    #endregion
+}

--- a/Assets/VRCBreeze/Editor/VRCBreezeEditor.cs.meta
+++ b/Assets/VRCBreeze/Editor/VRCBreezeEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 762392bb432f90046b2dc6a7c7203392
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCBreeze/Editor/VRCBreezeInstallerPass.cs
+++ b/Assets/VRCBreeze/Editor/VRCBreezeInstallerPass.cs
@@ -1,8 +1,4 @@
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using UnityEngine;
 using nadena.dev.ndmf;
-
 
 namespace VRCBreeze
 {

--- a/Assets/VRCBreeze/Editor/VRCBreezeInstallerPass.cs
+++ b/Assets/VRCBreeze/Editor/VRCBreezeInstallerPass.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using UnityEngine;
+using nadena.dev.ndmf;
+
+
+namespace VRCBreeze
+{
+    public sealed class VRCBreezeInstallerPass : Pass<VRCBreezeInstallerPass>
+    {
+        protected override void Execute(BuildContext context)
+        {
+            var extContext = context.Extension<VRCBreezeContext>();
+            foreach (var creator in context.AvatarRootObject.GetComponentsInChildren<VRCBreezeCreator>(true))
+                extContext.Install(creator);
+        }
+    }
+}

--- a/Assets/VRCBreeze/Editor/VRCBreezeInstallerPass.cs.meta
+++ b/Assets/VRCBreeze/Editor/VRCBreezeInstallerPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45fbc7214f2587f4aa6bbc24f74b1ca9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCBreeze/Editor/VRCBreezePlugin.cs
+++ b/Assets/VRCBreeze/Editor/VRCBreezePlugin.cs
@@ -8,7 +8,7 @@ namespace VRCBreeze
     {
         protected override void Configure()
         {
-            InPhase(BuildPhase.Generating)
+            InPhase(BuildPhase.Transforming)
                 .AfterPlugin("nadena.dev.modular-avatar")
                 .WithRequiredExtension(typeof(VRCBreezeContext), seq => seq.Run(VRCBreezeInstallerPass.Instance));
         }

--- a/Assets/VRCBreeze/Editor/VRCBreezePlugin.cs
+++ b/Assets/VRCBreeze/Editor/VRCBreezePlugin.cs
@@ -1,0 +1,16 @@
+using nadena.dev.ndmf;
+
+[assembly: ExportsPlugin(typeof(VRCBreeze.VRCBreezePlugin))]
+
+namespace VRCBreeze
+{
+    public sealed class VRCBreezePlugin : Plugin<VRCBreezePlugin>
+    {
+        protected override void Configure()
+        {
+            InPhase(BuildPhase.Generating)
+                .AfterPlugin("nadena.dev.modular-avatar")
+                .WithRequiredExtension(typeof(VRCBreezeContext), seq => seq.Run(VRCBreezeInstallerPass.Instance));
+        }
+    }
+}

--- a/Assets/VRCBreeze/Editor/VRCBreezePlugin.cs.meta
+++ b/Assets/VRCBreeze/Editor/VRCBreezePlugin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0658a04f86c47043a02e2b81f5771f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCBreeze/Prefabs/VRCBreeze.prefab
+++ b/Assets/VRCBreeze/Prefabs/VRCBreeze.prefab
@@ -237,7 +237,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4609851767951380918}
   - component: {fileID: 972875559399596749}
-  - component: {fileID: 4971824940724616761}
   - component: {fileID: 1880038099476336501}
   - component: {fileID: 8394457485246796443}
   m_Layer: 0
@@ -284,30 +283,7 @@ MonoBehaviour:
   rotationConstraint: {fileID: 215003812590759311}
   sourceAnimatorController: {fileID: 9100000, guid: ab69a457498b20d4ab913323b02ef46a,
     type: 2}
-  id: 0
   enableGizmos: 0
---- !u!114 &4971824940724616761
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4142863996460731324}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1bb122659f724ebf85fe095ac02dc339, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  animator: {fileID: 9100000, guid: ab69a457498b20d4ab913323b02ef46a, type: 2}
-  layerType: 5
-  deleteAttachedAnimator: 1
-  pathMode: 1
-  matchAvatarWriteDefaults: 0
-  relativePathRoot:
-    referencePath: 
-    targetObject: {fileID: 0}
-  layerPriority: 0
-  mergeAnimatorMode: 0
 --- !u!114 &1880038099476336501
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/VRCBreeze/Scripts/VRCBreezeCreator.cs
+++ b/Assets/VRCBreeze/Scripts/VRCBreezeCreator.cs
@@ -1,10 +1,10 @@
-#if UNITY_EDITOR
-using VRC.SDKBase;
-using VRC.SDK3.Dynamics.PhysBone.Components;
-using VRC.SDK3.Dynamics.Constraint.Components;
 using UnityEngine;
-using UnityEditor.Animations;
-using UnityEditor;
+using VRC.SDKBase;
+using VRC.SDK3.Avatars.Components;
+using VRC.SDK3.Dynamics.Constraint.Components;
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.runtime;
+using nadena.dev.ndmf.animator;
 
 namespace VRCBreeze
 {
@@ -22,345 +22,52 @@ namespace VRCBreeze
     }
 
     [AddComponentMenu("VRC Breeze Creator")]
-    public class VRCBreezeCreator : MonoBehaviour
+    [HelpURL("https://github.com/Kadeko/VRCBreeze/")]
+    public class VRCBreezeCreator : MonoBehaviour, IEditorOnly, IVirtualizeAnimatorController
     {
         #region Variables
-        [SerializeField, Header("Wind Settings:"), Tooltip("Assign your desired Wind Anchor here. We recommend that to be 'Hips' or 'Head'.")]
-        private GameObject windAnchor;
+        [Header("Wind Settings:"), Tooltip("Assign your desired Wind Anchor here. We recommend that to be 'Hips' or 'Head'.")]
+        public GameObject windAnchor;
 
-        [SerializeField, Tooltip("How strong is the wind."), Min(0f)]
-        private float windStrength = 10f;
+        [Tooltip("How strong is the wind."), Min(0f)]
+        public float windStrength = 10f;
 
-        [SerializeField, Tooltip("If enabled, Bone keyframes are slightly randomized around the middle of the AnimationClip.\nIf disabled, Bone keyframes are placed in the middle of the AnimationClip.")]
-        private bool moveBonesAtRandomTime = false;
-        
-        [Space, SerializeField, Tooltip("Drag any root bones here!")]
-        private BoneObjects[] boneObjects;
+        [Tooltip("If enabled, Bone keyframes are slightly randomized around the middle of the AnimationClip.\nIf disabled, Bone keyframes are placed in the middle of the AnimationClip.")]
+        public bool moveBonesAtRandomTime = false;
 
-        [SerializeField, Header("Important Components:"), Tooltip("Do not remove this, unless you know what you are doing!\nYou can find this component at: 'Rotation_Source' GameObject.")]
-        private VRCRotationConstraint rotationConstraint;
+        [Space, Tooltip("Drag any root bones here!")]
+        public BoneObjects[] boneObjects;
 
-        [SerializeField, Tooltip("Requires 'FX_Breeze' Animator Controller.\nYou can find this at: 'Assets/VRCBreeze/Animations/FX_Breeze.controller'")]
-        private AnimatorController sourceAnimatorController;
+        [Header("Important Components:"), Tooltip("Do not remove this, unless you know what you are doing!\nYou can find this component at: 'Rotation_Source' GameObject.")]
+        public VRCRotationConstraint rotationConstraint;
 
-        [Space, SerializeField, Header("Debug:"), Tooltip("If you want to keep your animations, change this number. Otherwise leave it at 0.")]
-        private int id = 0;
+        [Tooltip("Requires 'FX_Breeze' Animator Controller.\nYou can find this at: 'Assets/VRCBreeze/Animations/FX_Breeze.controller'")]
+        public RuntimeAnimatorController sourceAnimatorController;
 
         [SerializeField]
         private bool enableGizmos = false;
 
-        private AnimationClip[] generatedClips = new AnimationClip[4];
-
-        private const string PREFIX = "[<color=cyan>VRCBreezeCreator</color>]";
+        private bool isAbsolute;
         #endregion
 
-        public void Initialize()
+        #region VirtualizeAnimatorController
+        RuntimeAnimatorController IVirtualizeAnimatorController.AnimatorController
         {
-            if (this.transform.parent == null)
-            {
-                Debug.LogError($"{PREFIX} VRCBreeze.prefab is not under the Avatar!");
-                return;
-            }
-            if (boneObjects.Length == 0)
-            {
-                Debug.LogError($"{PREFIX} Missing Bones! Assign your bones in Bone Objects list!");
-                return;
-            }
-
-            SetupPhysbones();
-
-            CreateBreezeAnimation(Direction.Forward);
-            CreateBreezeAnimation(Direction.Backward);
-            CreateBreezeAnimation(Direction.Left);
-            CreateBreezeAnimation(Direction.Right);
-            Debug.Log($"{PREFIX} Successfully generated animations at: 'Assets/VRCBreeze/Animations/Generated/'!");
-
-            AssignAnimationsToController();
-            SetConstraints();
+            get => sourceAnimatorController;
+            set => sourceAnimatorController = value;
         }
 
-        #region Animation Creation
-        private void CreateBreezeAnimation(Direction direction)
+        object IVirtualizeAnimatorController.TargetControllerKey => VRCAvatarDescriptor.AnimLayerType.FX;
+
+        string IVirtualizeAnimatorController.GetMotionBasePath(object ndmfBuildContext, bool clearPath)
         {
-            AnimationClip clip = new AnimationClip();
-            clip.legacy = false;
-
-            for (int i = 0; i < boneObjects.Length; i++)
-            {
-                if (boneObjects[i].breezeBone == null || boneObjects[i].breezeBoneWeight == 0f) continue;
-
-                Transform armatureRoot = FindArmatureRoot(boneObjects[i].breezeBone.transform);
-                string path = AnimationUtility.CalculateTransformPath(boneObjects[i].breezeBone.transform, armatureRoot);
-
-                Vector3 axis = Vector3.up;
-                float angle = windStrength * boneObjects[i].breezeBoneWeight;
-
-                switch (direction)
-                {
-                    case Direction.Forward:
-                        axis = boneObjects[i].invertZ ? Vector3.forward : Vector3.back;
-                        angle = Mathf.Abs(angle);
-                        break;
-                    case Direction.Backward:
-                        axis = boneObjects[i].invertZ ? Vector3.back : Vector3.forward;
-                        angle = Mathf.Abs(angle);
-                        break;
-                    case Direction.Left:
-                        axis = boneObjects[i].invertX ? Vector3.right : Vector3.left;
-                        angle = Mathf.Abs(angle);
-                        break;
-                    case Direction.Right:
-                        axis = boneObjects[i].invertX ? Vector3.left : Vector3.right;
-                        angle = Mathf.Abs(angle);
-                        break;
-                }
-
-                Quaternion worldStartRot = boneObjects[i].breezeBone.transform.rotation;
-                Vector3 rotationAxis = Vector3.Cross(Vector3.up, axis).normalized;
-                if (rotationAxis == Vector3.zero) 
-                    rotationAxis = Vector3.forward;
-
-                Quaternion worldMiddleRot = Quaternion.AngleAxis(angle, rotationAxis) * worldStartRot;
-
-                Quaternion localStartRot = boneObjects[i].breezeBone.transform.parent != null ? Quaternion.Inverse(boneObjects[i].breezeBone.transform.parent.rotation) * worldStartRot : worldStartRot;
-                Quaternion localMiddleRot = boneObjects[i].breezeBone.transform.parent != null ? Quaternion.Inverse(boneObjects[i].breezeBone.transform.parent.rotation) * worldMiddleRot: worldMiddleRot;
-
-                float keyframeTime = moveBonesAtRandomTime ? Random.Range(0.35f, 0.65f) : 0.5f;
-
-                AnimationCurve curveX = new AnimationCurve(new Keyframe(0f, localStartRot.x), new Keyframe(keyframeTime, localMiddleRot.x), new Keyframe(1f, localStartRot.x));
-                AnimationCurve curveY = new AnimationCurve(new Keyframe(0f, localStartRot.y), new Keyframe(keyframeTime, localMiddleRot.y), new Keyframe(1f, localStartRot.y));
-                AnimationCurve curveZ = new AnimationCurve(new Keyframe(0f, localStartRot.z), new Keyframe(keyframeTime, localMiddleRot.z), new Keyframe(1f, localStartRot.z));
-                AnimationCurve curveW = new AnimationCurve(new Keyframe(0f, localStartRot.w), new Keyframe(keyframeTime, localMiddleRot.w), new Keyframe(1f, localStartRot.w));
-
-                clip.SetCurve(path, typeof(Transform), "localRotation.x", curveX);
-                clip.SetCurve(path, typeof(Transform), "localRotation.y", curveY);
-                clip.SetCurve(path, typeof(Transform), "localRotation.z", curveZ);
-                clip.SetCurve(path, typeof(Transform), "localRotation.w", curveW);
-            }
-
-            AnimationClipSettings settings = new AnimationClipSettings { loopTime = true };
-            SetAnimationClipSettings(clip, settings);
-
-            string clipName = "N/A";
-            switch (direction)
-            {
-                case Direction.Left:
-                    clipName = "VRCBreeze_+X";
-                    generatedClips[(int)Direction.Left] = clip;
-                    break;
-                case Direction.Right:
-                    clipName = "VRCBreeze_-X";
-                    generatedClips[(int)Direction.Right] = clip;
-                    break;
-                case Direction.Forward:
-                    clipName = "VRCBreeze_+Z";
-                    generatedClips[(int)Direction.Forward] = clip;
-                    break;
-                case Direction.Backward:
-                    clipName = "VRCBreeze_-Z";
-                    generatedClips[(int)Direction.Backward] = clip;
-                    break;
-            }
-            string pathAsset = $"Assets/VRCBreeze/Animations/Generated/{this.transform.parent.name}_{id}_{clipName}.anim";
-            AssetDatabase.CreateAsset(clip, pathAsset);
-            AssetDatabase.SaveAssets();
-        }
-
-        private void SetAnimationClipSettings(AnimationClip clip, AnimationClipSettings settings)
-        {
-            var serializedClip = new SerializedObject(clip);
-            var settingsProperty = serializedClip.FindProperty("m_AnimationClipSettings");
-            settingsProperty.FindPropertyRelative("m_LoopTime").boolValue = settings.loopTime;
-            serializedClip.ApplyModifiedProperties();
-        }
-
-        private Transform FindArmatureRoot(Transform target)
-        {
-            Transform current = target;
-            while (current.parent != null && current != this.transform.parent.transform)
-            {
-                current = current.parent;
-            }
-            return current;
-        }
-        #endregion
-
-        #region Animator
-        private void AssignAnimationsToController()
-        {
-            if (sourceAnimatorController == null)
-            {
-                Debug.LogError($"{PREFIX} Missing Animator Controller! You can find this at: 'Assets/VRCBreeze/Animations/FX_Breeze.controller'");
-                return;
-            }
-
-            AnimatorControllerLayer fxLayer = null;
-            foreach (var layer in sourceAnimatorController.layers)
-            {
-                if (layer.name.ToLower() == "breeze")
-                {
-                    fxLayer = layer;
-                    break;
-                }
-            }
-            if (fxLayer == null)
-            {
-                Debug.LogError($"{PREFIX} Missing 'Breeze' Layer! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            ChildAnimatorState hairState = default;
-            foreach (var state in fxLayer.stateMachine.states)
-            {
-                if (state.state.name.ToLower() == "breeze blend tree")
-                {
-                    hairState = state;
-                    break;
-                }
-            }
-            if (hairState.state == null)
-            {
-                Debug.LogError($"{PREFIX} Missing 'Breeze Blend Tree' State! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            var blendTree = hairState.state.motion as BlendTree;
-            if (blendTree == null)
-            {
-                Debug.LogError($"{PREFIX} Missing Blend Tree! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            // Breeze Tree
-
-            BlendTree breezeTree = null;
-            foreach (var child in blendTree.children)
-            {
-                if (child.motion is BlendTree bt && bt.name.ToLower() == "breeze tree")
-                {
-                    breezeTree = bt;
-                    break;
-                }
-            }
-            if (breezeTree == null)
-            {
-                Debug.LogError($"{PREFIX} Missing 'Breeze Tree' BlendTree! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            // Breeze World
-
-            BlendTree breezeWorld = null;
-            foreach (var child in breezeTree.children)
-            {
-                if (child.motion is BlendTree bt && bt.name.ToLower() == "world")
-                {
-                    breezeWorld = bt;
-                    break;
-                }
-            }
-            if (breezeWorld == null)
-            {
-                Debug.LogError($"{PREFIX} Missing 'World' BlendTree! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            var worldChildren = breezeWorld.children;
-            if (worldChildren.Length < 4)
-            {
-                Debug.LogError($"{PREFIX} 'World' BlendTree has not enough empty motions! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            worldChildren[(int)Direction.Left].motion = generatedClips[(int)Direction.Left];
-            worldChildren[(int)Direction.Right].motion = generatedClips[(int)Direction.Right];
-            worldChildren[(int)Direction.Forward].motion = generatedClips[(int)Direction.Forward];
-            worldChildren[(int)Direction.Backward].motion = generatedClips[(int)Direction.Backward];
-
-            breezeWorld.children = worldChildren;
-
-            // Breeze Local
-
-            BlendTree breezeLocal = null;
-            foreach (var child in breezeTree.children)
-            {
-                if (child.motion is BlendTree bt && bt.name.ToLower() == "local")
-                {
-                    breezeLocal = bt;
-                    break;
-                }
-            }
-            if (breezeLocal == null)
-            {
-                Debug.LogError($"{PREFIX} Missing 'Local' BlendTree! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            var localChildren = breezeLocal.children;
-            if (localChildren.Length < 5)
-            {
-                Debug.LogError($"{PREFIX} 'Local' BlendTree has not enough empty motions! Make sure you have not changed anything, including names, inside 'FX_Layer'! Use 'FX_Layer (BACKUP)' to solve the problem.");
-                return;
-            }
-
-            localChildren[0].motion = generatedClips[(int)Direction.Forward];
-            localChildren[1].motion = generatedClips[(int)Direction.Left];
-            localChildren[2].motion = generatedClips[(int)Direction.Backward];
-            localChildren[3].motion = generatedClips[(int)Direction.Right];
-            localChildren[4].motion = generatedClips[(int)Direction.Forward];
-
-            breezeLocal.children = localChildren;
-
-            EditorUtility.SetDirty(sourceAnimatorController);
-            AssetDatabase.SaveAssets();
-
-            Debug.Log($"{PREFIX} Successfully assigned animations into FX Layer!");
-        }
-        #endregion
-
-        #region Components
-        private void SetConstraints()
-        {
-            if (rotationConstraint == null)
-            {
-                Debug.LogError($"{PREFIX} Missing Rotation Constraint component! You can find this component at: 'Rotation_Source' GameObject.");
-                return;
-            }
-            if (windAnchor == null)
-            {
-                Debug.LogError($"{PREFIX} Missing Wind Anchor! We recommend that to be 'Hips' or 'Head'.");
-                return;
-            }
-            rotationConstraint.Sources.Clear();
-
-            rotationConstraint.Sources.Add(new()
-            {
-                SourceTransform = windAnchor.transform,
-                Weight = 1f
-            });
-
-            rotationConstraint.ActivateConstraint();
-            Debug.Log($"{PREFIX} Successfully assigned & activated '{rotationConstraint.gameObject.name}' constraint!");
-        }
-
-        private void SetupPhysbones()
-        {
-            int successfulObjCount = 0;
-            for (int i = 0; i < boneObjects.Length; i++)
-            {
-                if (boneObjects[i].breezeBone == null) continue;
-                VRCPhysBone[] physBone = boneObjects[i].breezeBone.GetComponentsInChildren<VRCPhysBone>(true);
-                if (physBone != null && physBone.Length > 0)
-                {
-                    foreach (var bone in physBone)
-                    {
-                        if (bone == null) continue;
-                        bone.isAnimated = true;
-                    }
-                }
-                successfulObjCount++;
-            }
-            Debug.Log($"{PREFIX} Successfully set 'IsAnimated' to 'true' for Physbones! [{successfulObjCount}/{boneObjects.Length}]");
+            var wasAbsolute = isAbsolute;
+            isAbsolute |= clearPath;
+#if UNITY_EDITOR
+            if (!wasAbsolute && ndmfBuildContext is BuildContext context)
+                return RuntimeUtil.RelativePath(context.AvatarRootTransform, transform) ?? "";
+#endif
+            return "";
         }
         #endregion
 
@@ -415,78 +122,4 @@ namespace VRCBreeze
         Forward,    // +Z
         Backward,   // -Z
     }
-
-    #region Editor
-    [CustomEditor(typeof(VRCBreezeCreator))]
-    public class VRCBreezeEditor : Editor
-    {
-        private Texture2D header_mainTexture;
-        private Rect headerSection;
-        private float headerSize = 100f;
-
-        private static GUIStyle DefaultButtonStyle => new GUIStyle(GUI.skin.button)
-        {
-            fontStyle = FontStyle.Normal,
-            alignment = TextAnchor.MiddleCenter,
-            richText = true,
-            wordWrap = true,
-        };
-        private static GUIStyle DefaultButtonStyleUnwrap => new GUIStyle(GUI.skin.button)
-        {
-            fontStyle = FontStyle.Normal,
-            alignment = TextAnchor.MiddleCenter,
-            richText = true,
-            wordWrap = false,
-        };
-
-        private void OnEnable()
-        {
-            header_mainTexture = Resources.Load<Texture2D>("VRCB_Header");
-        }
-
-        public override void OnInspectorGUI()
-        {
-            VRCBreezeCreator creator = (VRCBreezeCreator)target;
-            if (creator == null) return;
-
-            if (header_mainTexture != null)
-            {
-                headerSection.height = headerSize;
-                headerSection.width = headerSize * 3.94f;
-                headerSection.x = 0f;/*(Screen.width / 2) - headerSection.width / 2;*/
-                headerSection.y = 0f;
-
-                GUI.DrawTexture(headerSection, header_mainTexture);
-
-                EditorGUILayout.Space(headerSection.height);
-            }
-
-            EditorGUILayout.BeginHorizontal();
-            //GUILayout.FlexibleSpace();
-            EditorGUILayout.LabelField("Created by:", GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/);
-            if (GUILayout.Button("Kadeko", DefaultButtonStyleUnwrap, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/))
-                Application.OpenURL("https://x.com/kadeko_vrc");
-            if (GUILayout.Button("InviaWaffles", DefaultButtonStyleUnwrap, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/))
-                Application.OpenURL("https://x.com/InviaWaffles");
-            EditorGUILayout.EndHorizontal();
-
-            if (GUILayout.Button("Help & Documentation", DefaultButtonStyleUnwrap, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 6f - 20f)*/))
-                Application.OpenURL("https://github.com/Kadeko/VRCBreeze/");
-
-            EditorGUILayout.Space(15f);
-
-            DrawDefaultInspector();
-
-            EditorGUILayout.Space(10f);
-
-            EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button(new GUIContent("Apply VRCBreeze to Avatar", "Applies this feature into Avatar. You can remove this component after."), DefaultButtonStyle, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 2f - 20f)*/))
-                creator.Initialize();
-            if (GUILayout.Button(new GUIContent("Finish", "Removes this component. You can revert it by right clicking the component -> Removed Components -> Revert."), DefaultButtonStyle, GUILayout.Height(25f)/*, GUILayout.Width(Screen.width / 2f - 20f)*/))
-                DestroyImmediate(creator);
-            EditorGUILayout.EndHorizontal();
-        }
-    }
-    #endregion
 }
-#endif


### PR DESCRIPTION
This PR I have moved all installation logic that originally requires button click to a dedicated NDMF plugin pass, and it will runs *after* Modular Avatar. Since this new logic flow utilizes the same animator controller manipulation pipeline that Modular Avatar uses, it should fixes issues that caused by game object renamed while avatar is building.

Also, PhysBone seeking logic has been reimplemented, which will more comprehensively configurate whether should it handle animated bone.

I tried to test everything and in theory should works fine, but I don't know if there's any edge cases missed.